### PR TITLE
Swap out the slashes for msysgit bash support

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function writeShim_ (from, to, prog, args, cb) {
 
   if (shLongProg) {
     sh = sh
-        + "basedir=`dirname \"$0\"`\n"
+        + "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")\n"
         + "\n"
         + "case `uname` in\n"
         + "    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;\n"

--- a/test/basic.js
+++ b/test/basic.js
@@ -31,7 +31,7 @@ test('env shebang', function (t) {
 
     t.equal(fs.readFileSync(to, 'utf8'),
             "#!/bin/sh"+
-            "\nbasedir=`dirname \"$0\"`"+
+            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")"+
             "\n"+
             "\ncase `uname` in"+
             "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;"+
@@ -67,7 +67,7 @@ test('env shebang with args', function (t) {
 
     t.equal(fs.readFileSync(to, 'utf8'),
             "#!/bin/sh"+
-            "\nbasedir=`dirname \"$0\"`"+
+            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")"+
             "\n"+
             "\ncase `uname` in"+
             "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;"+
@@ -103,7 +103,7 @@ test('explicit shebang', function (t) {
 
     t.equal(fs.readFileSync(to, 'utf8'),
             "#!/bin/sh" +
-            "\nbasedir=`dirname \"$0\"`" +
+            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")" +
             "\n" +
             "\ncase `uname` in" +
             "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;" +
@@ -140,7 +140,7 @@ test('explicit shebang with args', function (t) {
 
     t.equal(fs.readFileSync(to, 'utf8'),
             "#!/bin/sh" +
-            "\nbasedir=`dirname \"$0\"`" +
+            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")" +
             "\n" +
             "\ncase `uname` in" +
             "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;" +


### PR DESCRIPTION
I was unable to use npm to install a node based git command extension. The `dirname "$0"` command in the shim script always return `.` due to the path returning being a windows path when running in git bash. After playing around and research I found that other git extensions use `sed` to swap out the slashes for similar reasons.

Change I used comes from: https://github.com/nvie/gitflow/blob/develop/git-flow#L50

I couldn't come up with a good test to prove the issue and the fix. Everything I tried kept resolving. I did copy the `index.js` script into my local npm install and reinstalled the troublesome npm package. After that things worked fine. Tested on Windows 7 git bash and normal command prompt.