### PR TITLE
Add "@" to the start of single line .cmd files

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function writeShim_ (from, to, prog, args, cb) {
         + "  " + prog + " " + args + " " + target + " %*\r\n"
         + ")"
   } else {
-    cmd = prog + " " + args + " " + target + " %*\r\n"
+    cmd = "@" + prog + " " + args + " " + target + " %*\r\n"
   }
 
   // #!/bin/sh

--- a/test/basic.js
+++ b/test/basic.js
@@ -15,7 +15,7 @@ test('no shebang', function (t) {
     t.equal(fs.readFileSync(to, 'utf8'),
             "\"$basedir/from.exe\"   \"$@\"\nexit $?\n")
     t.equal(fs.readFileSync(to + '.cmd', 'utf8'),
-            "\"%~dp0\\from.exe\"   %*\r\n")
+            "@\"%~dp0\\from.exe\"   %*\r\n")
     t.end()
   })
 })


### PR DESCRIPTION
To prevent the command from being echoed to the console, add a "@" to the start of the line.