### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "graceful-fs": ">3.0.1 <4.0.0-0",
+    "graceful-fs": "^4.1.2",
     "mkdirp": "~0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714